### PR TITLE
Fix for TMC Charts detector types

### DIFF
--- a/MOE.Common/Business/WCFServiceLibrary/TMCOptions.cs
+++ b/MOE.Common/Business/WCFServiceLibrary/TMCOptions.cs
@@ -97,8 +97,10 @@ namespace MOE.Common.Business.WCFServiceLibrary
             CreateLaneTypeCharts(signal, "Vehicle", laneTypes, movementTypes, directions, plans, TmcInfo);
             CreateLaneTypeCharts(signal, "Exit", laneTypes, movementTypes, directions, plans, TmcInfo);
             CreateLaneTypeCharts(signal, "Bike", laneTypes, movementTypes, directions, plans, TmcInfo);
-
-
+            CreateLaneTypeCharts(signal, "Pedestrian", laneTypes, movementTypes, directions, plans, TmcInfo);
+            CreateLaneTypeCharts(signal, "Bus", laneTypes, movementTypes, directions, plans, TmcInfo);
+            CreateLaneTypeCharts(signal, "Light Rail Transit", laneTypes, movementTypes, directions, plans, TmcInfo);
+            CreateLaneTypeCharts(signal, "High Occupancy Vehicle", laneTypes, movementTypes, directions, plans, TmcInfo);
             return TmcInfo;
         }
 


### PR DESCRIPTION
TMC Charts will now be created for Lane-by-Lane count detectors if they are marked as Pedestrian, Bus, Light rail, or HOV. The fix has now been tested and verified that it works.