### PR TITLE
Creates toggle for Permissive Phases (T&A measure)

### DIFF
--- a/MOE.Common/Business/WCFServiceLibrary/TimingAndActuationsOptions.cs
+++ b/MOE.Common/Business/WCFServiceLibrary/TimingAndActuationsOptions.cs
@@ -123,6 +123,11 @@ namespace MOE.Common.Business.WCFServiceLibrary
         [Required]
         [DataMember]
         public bool ShowRawEventData { get; set; }
+
+        [Display(Name = "Show Permissive Phases")]
+        [Required]
+        [DataMember]
+        public bool ShowPermissivePhases { get; set; }
         
         public List<int> GlobalEventCodesList { get; set; }
         public List<int> GlobalEventParamsList { get; set; }
@@ -160,6 +165,7 @@ namespace MOE.Common.Business.WCFServiceLibrary
             ShowHeaderForEachPhase = false;
             ShowLaneByLaneCount = true;
             ShowLinesStartEnd = true;
+            ShowPermissivePhases = true;
 
             ShowPedestrianActuation = true;
             ShowPedestrianIntervals = true;
@@ -245,7 +251,11 @@ namespace MOE.Common.Business.WCFServiceLibrary
             //Parallel.ForEach(timingAndActuationsForPhases, timingAndActutionsForPhase =>
                 foreach (var timingAndActutionsForPhase in timingAndActuationsForPhases)
             {
-                GetChart(timingAndActutionsForPhase);
+                if (timingAndActutionsForPhase.GetPermissivePhase==false ||
+                    ShowPermissivePhases)
+                {
+                    GetChart(timingAndActutionsForPhase);
+                }
            // });
             }
 

--- a/SPM/Controllers/DefaultChartsController.cs
+++ b/SPM/Controllers/DefaultChartsController.cs
@@ -177,7 +177,6 @@ namespace SPM.Controllers
                                                           metricOptions.ShowLinesStartEnd.ToString().ToLower() + "," +
                                                           metricOptions.ShowEventPairs.ToString().ToLower() +
                                                           metricOptions.ShowRawEventData.ToString().ToLower() + "," +
-                                                          metricOptions.ShowPermissivePhases.ToString().ToLower() + "," +
 
                                                           "); CreateMetric();";
             return View("Index", defaultChartsViewModel);

--- a/SPM/Controllers/DefaultChartsController.cs
+++ b/SPM/Controllers/DefaultChartsController.cs
@@ -177,6 +177,8 @@ namespace SPM.Controllers
                                                           metricOptions.ShowLinesStartEnd.ToString().ToLower() + "," +
                                                           metricOptions.ShowEventPairs.ToString().ToLower() +
                                                           metricOptions.ShowRawEventData.ToString().ToLower() + "," +
+                                                          metricOptions.ShowPermissivePhases.ToString().ToLower() + "," +
+
                                                           "); CreateMetric();";
             return View("Index", defaultChartsViewModel);
         }

--- a/SPM/Scripts/GetMetrics.js
+++ b/SPM/Scripts/GetMetrics.js
@@ -153,6 +153,7 @@ function GetTimingAndActuationsMetric(metricTypeID) {
     tosend.ShowLinesStartEnd = $("#ShowLinesStartEnd").is(":checked");
     tosend.ShowEventPairs = $("#ShowEventPairs").is(":checked");
     tosend.ShowRawEventData = $("#ShowRawEventData").is(":checked");
+    tosend.ShowPermissivePhases = $("#ShowPermissivePhases").is(":checked");
     tosend.ExtendVsdSearch = $("#ExtendVsdSearch").val();
     tosend.ShowVehicleSignalDisplay = $("#ShowVehicleSignalDisplay").is(":checked");
     tosend.ShowPedestrianIntervals = $("#ShowPedestrianIntervals").is(":checked");

--- a/SPM/Views/DefaultCharts/TimingAndActuationsOptions.cshtml
+++ b/SPM/Views/DefaultCharts/TimingAndActuationsOptions.cshtml
@@ -57,20 +57,24 @@
         <div id="LaneCollapseOne" class="collapse">
             <div class="card-body" id="LaneDetectionPlaceHolder">
                 <div class="">
-                    @Html.EditorFor(model => model.ShowAllLanesInfo, new {htmlAttributes = new {@class = "", placeholder = "Auto"}})
-                    @Html.LabelFor(model => model.ShowAllLanesInfo, new {htmlAttributes = new {@class = "control-label"}})
+                    @Html.EditorFor(model => model.ShowAllLanesInfo, new { htmlAttributes = new { @class = "", placeholder = "Auto" } })
+                    @Html.LabelFor(model => model.ShowAllLanesInfo, new { htmlAttributes = new { @class = "control-label" } })
                 </div>
                 <div class="">
-                    @Html.EditorFor(model => model.ShowLinesStartEnd, new {htmlAttributes = new {@class = "", placeholder = "Auto"}})
-                    @Html.LabelFor(model => model.ShowLinesStartEnd, new {htmlAttributes = new {@class = "control-label"}})
+                    @Html.EditorFor(model => model.ShowLinesStartEnd, new { htmlAttributes = new { @class = "", placeholder = "Auto" } })
+                    @Html.LabelFor(model => model.ShowLinesStartEnd, new { htmlAttributes = new { @class = "control-label" } })
                 </div>
                 <div class="">
-                    @Html.EditorFor(model => model.ShowEventPairs, new {htmlAttributes = new {@class = "", placeholder = "Auto"}})
-                    @Html.LabelFor(model => model.ShowEventPairs, new {htmlAttributes = new {@class = "control-label"}})
+                    @Html.EditorFor(model => model.ShowEventPairs, new { htmlAttributes = new { @class = "", placeholder = "Auto" } })
+                    @Html.LabelFor(model => model.ShowEventPairs, new { htmlAttributes = new { @class = "control-label" } })
                 </div>
                 <div class="">
                     @Html.EditorFor(model => model.ShowRawEventData, new { htmlAttributes = new { @class = "", placeholder = "Auto" } })
                     @Html.LabelFor(model => model.ShowRawEventData, new { htmlAttributes = new { @class = "control-label" } })
+                </div>
+                <div class="">
+                    @Html.EditorFor(model => model.ShowPermissivePhases, new { htmlAttributes = new { @class = "", placeholder = "Auto" } })
+                    @Html.LabelFor(model => model.ShowPermissivePhases, new { htmlAttributes = new { @class = "control-label" } })
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adds a checkbox "Show Permissive Phases" in the Options for the Timing and Actuation measure. When toggled off (default is on), the charts for the permissive phases (usually shown in gray shading) are omitted from the results.