### PR TITLE
Remove redundant metric type

### DIFF
--- a/MOE.Common/Migrations/Configuration.cs
+++ b/MOE.Common/Migrations/Configuration.cs
@@ -1122,15 +1122,6 @@ namespace MOE.Common.Migrations
                 },
                 new MetricType
                 {
-                    MetricID = 31,
-                    ChartName = "Left Turn Gap Analysis",
-                    Abbreviation = "LTGA",
-                    ShowOnWebsite = true,
-                    ShowOnAggregationSite = false,
-                    DisplayOrder = 112
-                },
-                new MetricType
-                {
                     MetricID = 32,
                     ChartName = "Wait Time",
                     Abbreviation = "WT",


### PR DESCRIPTION
There are two places where the Left Turn Gap is added, the only difference being the display order. I didn't know which one you'd prefer so I removed the bottom.