### PR TITLE
Left turn gap fixes

### DIFF
--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnGapDurationAnalysis.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnGapDurationAnalysis.cs
@@ -56,7 +56,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             Dictionary<DateTime, double> acceptableGaps = new Dictionary<DateTime, double>();
             for (var tempDate = start.Date; tempDate <= end; tempDate = tempDate.AddDays(1))
             {
-                for (var tempStart = tempDate.Date.Add(startTime); tempStart <= tempDate.Date.Add(endTime); tempStart = tempStart.AddMinutes(15))
+                for (var tempStart = tempDate.Date.Add(startTime); tempStart < tempDate.Date.Add(endTime); tempStart = tempStart.AddMinutes(15))
                 {
                     if (daysOfWeek.Contains((int)start.DayOfWeek))
                     {

--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnPedestrianAnalysis.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnPedestrianAnalysis.cs
@@ -93,7 +93,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             for (var tempDate = start.Date; tempDate <= end; tempDate = tempDate.AddDays(1))
             {
                 if (daysOfWeek.Contains((int)start.DayOfWeek))
-                    for (var tempstart = tempDate.Date.Add(startTime); tempstart <= tempDate.Add(endTime); tempstart = tempstart.AddMinutes(15))
+                    for (var tempstart = tempDate.Date.Add(startTime); tempstart < tempDate.Add(endTime); tempstart = tempstart.AddMinutes(15))
                     {
                         if (cycleAggregations.Where(c => c.BinStartTime >= tempstart && c.BinStartTime < tempstart.AddMinutes(15)).Any())
                         {

--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnPedestrianAnalysis.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnPedestrianAnalysis.cs
@@ -48,10 +48,15 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             }
             var result = new PedActuationResult();
             if (cycleAverage.CycleAverage == 0)
-                result.CyclesWithPedCalls = 0;
+            {
+                result.CyclesWithPedCallsPercent = 0;
+                result.CyclesWithPedCallsNum = 0;
+            }
             else
-                //result.PedActuationPercent = pedCycleAverage.PedCycleAverage / cycleAverage.CycleAverage;
-            result.CyclesWithPedCalls = pedCycleAverage.PedCycleAverage / cycleAverage.CycleAverage;
+            {
+                result.CyclesWithPedCallsPercent = pedCycleAverage.PedCycleAverage / cycleAverage.CycleAverage;
+                result.CyclesWithPedCallsNum = (int)pedCycleAverage.PedCycleAverage;
+            }
             result.PercentCyclesWithPedsList = cycleList;
             result.Direction = approach.DirectionType.Abbreviation + approach.Detectors.FirstOrDefault()?.MovementType.Abbreviation;
             result.OpposingDirection = signal.Approaches.Where(a => a.ProtectedPhaseNumber == opposingPhase).FirstOrDefault()?.DirectionType.Abbreviation;

--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnReportPreCheck.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnReportPreCheck.cs
@@ -299,7 +299,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
         //}
 
         public static Dictionary<TimeSpan, int> GetAMPMPeakFlowRate(string signalId, int approachId, DateTime startDate, DateTime endDate, TimeSpan amStartTime,
-            TimeSpan amEndTime, TimeSpan pmStartTime, TimeSpan pmEndTime, int[] daysOfWeek, ISignalsRepository signalsRepository, 
+            TimeSpan amEndTime, TimeSpan pmStartTime, TimeSpan pmEndTime, int[] daysOfWeek, ISignalsRepository signalsRepository,
             IApproachRepository approachRepository, IDetectorEventCountAggregationRepository detectorEventCountAggregationRepository)
         {
             if (!signalsRepository.Exists(signalId))

--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnReportPreCheck.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/LeftTurnReportPreCheck.cs
@@ -299,7 +299,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
         //}
 
         public static Dictionary<TimeSpan, int> GetAMPMPeakFlowRate(string signalId, int approachId, DateTime startDate, DateTime endDate, TimeSpan amStartTime,
-            TimeSpan amEndTime, TimeSpan pmStartTime, TimeSpan pmEndTime, int[] daysOfWeek, ISignalsRepository signalsRepository,
+            TimeSpan amEndTime, TimeSpan pmStartTime, TimeSpan pmEndTime, int[] daysOfWeek, ISignalsRepository signalsRepository, 
             IApproachRepository approachRepository, IDetectorEventCountAggregationRepository detectorEventCountAggregationRepository)
         {
             if (!signalsRepository.Exists(signalId))
@@ -320,13 +320,13 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             }
             List<TimeSpan> distinctTimeSpans = volumeAggregations.Select(v => v.BinStartTime.TimeOfDay).Distinct().OrderBy(v => v).ToList();
 
-            Dictionary<TimeSpan, int> averageByBin = GetAveragesForBins(volumeAggregations, distinctTimeSpans);
+            Dictionary<TimeSpan, int> averageByBin = GetAveragesForBinsByTimeSpan(volumeAggregations, distinctTimeSpans);
 
             Dictionary<TimeSpan, int> hourlyFlowRates = GetHourlyFlowRates(distinctTimeSpans, averageByBin);
 
             var allDetectorsFlowRate = GetAmPmPeaks(amStartTime, amEndTime, pmStartTime, pmEndTime, hourlyFlowRates);
 
-            return GetLeftTurnAMPMPeakFlowRates(signalId, startDate, endDate, amStartTime, amEndTime, pmStartTime, pmEndTime, daysOfWeek, signalsRepository, detectorEventCountAggregationRepository, distinctTimeSpans, allDetectorsFlowRate);
+            return GetLeftTurnAMPMPeakFlowRates(signalId, startDate, endDate, amStartTime, amEndTime, pmStartTime, pmEndTime, daysOfWeek, signalsRepository, detectorEventCountAggregationRepository, distinctTimeSpans, allDetectorsFlowRate, approachId);
         }
 
         private static Dictionary<TimeSpan, int> GetLeftTurnAMPMPeakFlowRates(string signalId,
@@ -340,7 +340,8 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
                                                                               ISignalsRepository signalsRepository,
                                                                               IDetectorEventCountAggregationRepository detectorEventCountAggregationRepository,
                                                                               List<TimeSpan> distinctTimeSpans,
-                                                                              Dictionary<TimeSpan, int> allDetectorsFlowRate)
+                                                                              Dictionary<TimeSpan, int> allDetectorsFlowRate,
+                                                                              int approachId)
         {
             List<Models.Detector> leftTurndetectors = GetLeftTurnLaneByLaneDetectorsForSignal(signalId, startDate, signalsRepository);
             if (!leftTurndetectors.Any())
@@ -354,7 +355,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             {
                 throw new NotSupportedException("No Left Turn Detector Activation Aggregations found");
             }
-            Dictionary<TimeSpan, int> leftTurnAverageByBin = GetAveragesForBins(leftTurnVolumeAggregations, distinctTimeSpans);
+            Dictionary<TimeSpan, int> leftTurnAverageByBin = GetAveragesForBinsByApproach(leftTurnVolumeAggregations, distinctTimeSpans, approachId); //add approach id
             Dictionary<TimeSpan, int> leftTurnHourlyFlowRates = GetHourlyFlowRates(distinctTimeSpans, leftTurnAverageByBin);
             Dictionary<TimeSpan, int> leftTurnAmPmPeaks = new Dictionary<TimeSpan, int>();
             leftTurnAmPmPeaks.Add(allDetectorsFlowRate.First().Key,
@@ -397,8 +398,28 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
             return hourlyFlowRates;
         }
 
-        public static Dictionary<TimeSpan, int> GetAveragesForBins(List<DetectorEventCountAggregation> volumeAggregations,
-                                                                   List<TimeSpan> distinctTimeSpans)
+        public static Dictionary<TimeSpan, int> GetAveragesForBinsByTimeSpan(List<DetectorEventCountAggregation> volumeAggregations,
+                                                           List<TimeSpan> distinctTimeSpans)
+        {
+            Dictionary<TimeSpan, int> averageByBin = new Dictionary<TimeSpan, int>();
+            foreach (TimeSpan time in distinctTimeSpans)
+            {
+                var average = Convert.ToInt32(volumeAggregations
+                    .Where(v => v.BinStartTime.TimeOfDay == time)
+                    .GroupBy(v => v.BinStartTime.Day).Select(v => new
+                    {
+                        sum = v.Sum(a => a.EventCount)
+                    }).Average(v => v.sum)
+                );
+
+                averageByBin.Add(time, average);
+            };
+            return averageByBin;
+        }
+
+        public static Dictionary<TimeSpan, int> GetAveragesForBinsByApproach(List<DetectorEventCountAggregation> volumeAggregations,
+                                                                   List<TimeSpan> distinctTimeSpans,
+                                                                   int approachId)
         {
             Dictionary<TimeSpan, int> averageByBin = new Dictionary<TimeSpan, int>();
 
@@ -407,6 +428,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
                 int average = Convert.ToInt32(
                     Math.Round(volumeAggregations
                     .Where(v => v.BinStartTime.TimeOfDay == time)
+                    .Where(v => v.ApproachId == approachId)
                     .Average(v => v.EventCount)
                     ));
                 averageByBin.Add(time, average);

--- a/ATSPM.Application.Reports/Business/LeftTurnGapReport/PedActuationResult.cs
+++ b/ATSPM.Application.Reports/Business/LeftTurnGapReport/PedActuationResult.cs
@@ -7,8 +7,8 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport
 {
     public class PedActuationResult
     {
-        public double PedActuationPercent { get; set; }
-        public double CyclesWithPedCalls { get; set; }
+        public int CyclesWithPedCallsNum { get; set; }
+        public double CyclesWithPedCallsPercent { get; set; }
         public Dictionary<DateTime, double> PercentCyclesWithPedsList { get; set; }
         public string Direction { get; set; }
         public string OpposingDirection { get; set; }

--- a/ATSPM.Application.Reports/Controllers/LeftTurnReport.cs
+++ b/ATSPM.Application.Reports/Controllers/LeftTurnReport.cs
@@ -56,7 +56,7 @@ namespace ATSPM.Application.Reports.Controllers
         {
             var amStartTime = new TimeSpan(6, 0, 0);
             var amEndTime = new TimeSpan(9, 0, 0);
-            var pmStartTime = new TimeSpan(15, 0, 0);
+            var pmStartTime = new TimeSpan(14, 0, 0);
             var pmEndTime = new TimeSpan(18, 0, 0);
 
             var approach = _approachRepository.GetApproachByApproachID(parameters.ApproachId);

--- a/ATSPM.Application.Reports/Controllers/LeftTurnReport.cs
+++ b/ATSPM.Application.Reports/Controllers/LeftTurnReport.cs
@@ -56,8 +56,8 @@ namespace ATSPM.Application.Reports.Controllers
         {
             var amStartTime = new TimeSpan(6, 0, 0);
             var amEndTime = new TimeSpan(9, 0, 0);
-            var pmStartTime = new TimeSpan(14, 0, 0);
-            var pmEndTime = new TimeSpan(18, 0, 0);
+            var pmStartTime = new TimeSpan(15, 0, 0);
+            var pmEndTime = new TimeSpan(19, 0, 0);
 
             var approach = _approachRepository.GetApproachByApproachID(parameters.ApproachId);
             var dataCheck = new DataCheckResult();
@@ -101,7 +101,7 @@ namespace ATSPM.Application.Reports.Controllers
             var flowRate = LeftTurnReportPreCheck.GetAMPMPeakFlowRate(parameters.SignalId, parameters.ApproachId, parameters.StartDate, parameters.EndDate, amStartTime,
             amEndTime, pmStartTime, pmEndTime, parameters.DaysOfWeek, _signalRepository, _approachRepository, _detectorEventCountAggregationRepository);
             dataCheck.LeftTurnVolumeOk = flowRate.First().Value >= parameters.VolumePerHourThreshold
-                && flowRate.Last().Value >= parameters.VolumePerHourThreshold;
+                || flowRate.Last().Value >= parameters.VolumePerHourThreshold;
 
             var gapOut = leftTurnReportPreCheck.GetAMPMPeakGapOut(parameters.SignalId, parameters.ApproachId, parameters.StartDate, parameters.EndDate, amStartTime,
             amEndTime, pmStartTime, pmEndTime, parameters.DaysOfWeek);

--- a/ATSPM.Application.ReportsTests/Business/LeftTurnGapReport/LeftTurnReportPreCheckTests.cs
+++ b/ATSPM.Application.ReportsTests/Business/LeftTurnGapReport/LeftTurnReportPreCheckTests.cs
@@ -252,7 +252,7 @@ namespace ATSPM.Application.Reports.Business.LeftTurnGapReport.Tests
                     distinctTimeSpans.Add(new TimeSpan(i, m, 0));
                 }
             }
-            var result = LeftTurnReportPreCheck.GetAveragesForBins(volumeAggregations, distinctTimeSpans);
+            var result = LeftTurnReportPreCheck.GetAveragesForBinsByTimeSpan(volumeAggregations, distinctTimeSpans);
             foreach (var avg in result)
             {
                 Assert.Equal(5, avg.Value);

--- a/ATSPM.Repositories.EntityFramework/ApproachSplitFailAggregationRepository.cs
+++ b/ATSPM.Repositories.EntityFramework/ApproachSplitFailAggregationRepository.cs
@@ -30,10 +30,10 @@ namespace ATSPM.Infrastructure.Repositories.EntityFramework
         {
             var splitFails = 0;
             if (_db.ApproachSplitFailAggregations.Any(r => r.ApproachId == approachId
-                                                           && r.BinStartTime >= start && r.BinStartTime <= end))
+                                                           && r.BinStartTime >= start && r.BinStartTime < end))
                 splitFails = _db.ApproachSplitFailAggregations.Where(r => r.ApproachId == approachId
                                                                           && r.BinStartTime >= start &&
-                                                                          r.BinStartTime <= end)
+                                                                          r.BinStartTime < end)
                     .Sum(r => r.SplitFailures);
             return splitFails;
         }
@@ -50,7 +50,7 @@ namespace ATSPM.Infrastructure.Repositories.EntityFramework
                                                                 && r.ApproachId == approachID
                                                                 && r.PhaseNumber == phase
                                                                 && r.BinStartTime >= startDate &&
-                                                                r.BinStartTime <= endDate).ToList();
+                                                                r.BinStartTime < endDate).ToList();
         }
 
         public bool Exists(string signalId, int phaseNumber, DateTime startDate, DateTime endDate)

--- a/MOE.Common/Business/WCFServiceLibrary/PedsVsFailuresOptions.cs
+++ b/MOE.Common/Business/WCFServiceLibrary/PedsVsFailuresOptions.cs
@@ -40,7 +40,7 @@ namespace MOE.Common.Business.WCFServiceLibrary
 
         [Required]
         [DataMember]
-        [Display(Name = "Percent Acceptable Cycles w/ Peds")]
+        [Display(Name = "Percent of Cycles w/ Peds")]
         public Dictionary<DateTime, double> PercentPedsList { get; internal set; }
         [Required]
         [DataMember]
@@ -128,7 +128,7 @@ namespace MOE.Common.Business.WCFServiceLibrary
             var gapSeries = new Series();
             gapSeries.ChartType = SeriesChartType.Line;
             gapSeries.Color = Color.FromArgb(92,136,218);
-            gapSeries.Name = "% of Accectable Cycles w/ Peds";
+            gapSeries.Name = "% of Acceptable Cycles w/ Peds";
             gapSeries.XValueType = ChartValueType.DateTime;
             gapSeries.Font = new Font("Arial", 10f);
             gapSeries.BorderWidth = 3;
@@ -160,7 +160,7 @@ namespace MOE.Common.Business.WCFServiceLibrary
             {
                 foreach (var bucket in PercentPedsList)
                 {
-                    chart.Series["% of Accectable Cycles w/ Peds"].Points.AddXY(bucket.Key.ToOADate(), bucket.Value * 100);
+                    chart.Series["% of Cycles w/ Peds"].Points.AddXY(bucket.Key.ToOADate(), bucket.Value * 100);
                 }
             }
             if (PercentFailuresList != null)

--- a/SPM/Controllers/LeftTurnGapReportController.cs
+++ b/SPM/Controllers/LeftTurnGapReportController.cs
@@ -246,8 +246,8 @@ namespace SPM.Controllers
                 0,
                 0,
                 31,
-                approachResult.AcceptableGapList,
-                approachResult.DemandList);
+                approachResult.PercentCyclesWithPedsList,
+                approachResult.PercentCyclesWithSplitFailList);
             approachResult.PedSplitFailChartImg = pedsVsFailuresOptions.CreateMetric().FirstOrDefault();
         }
 
@@ -291,8 +291,8 @@ namespace SPM.Controllers
             {
                 var PedResult = GetPedActuationResult(parameters, approachId);
 
-                approachResult.CyclesWithPedCallNum = PedResult.CyclesWithPedCallNum;
-                approachResult.CyclesWithPedCallPercent = PedResult.CyclesWithPedCallPercent;
+                approachResult.CyclesWithPedCallNum = PedResult.CyclesWithPedCallsNum;
+                approachResult.CyclesWithPedCallPercent = PedResult.CyclesWithPedCallsPercent;
                 approachResult.PedActuationsConsiderForStudy = PedResult.ConsiderForStudy;
                 approachResult.PercentCyclesWithPedsList = PedResult.PercentCyclesWithPedsList;
                 approachResult.Direction = PedResult.Direction;
@@ -336,7 +336,7 @@ namespace SPM.Controllers
             string url = "PedActuation";
             var result = GetResult(parameters, approachId, url);
             PedActuationResultViewModel pedActuationResult = JsonConvert.DeserializeObject<PedActuationResultViewModel>(result.Content);
-            pedActuationResult.ConsiderForStudy = pedActuationResult.CyclesWithPedCallPercent > 0.3d;
+            pedActuationResult.ConsiderForStudy = pedActuationResult.CyclesWithPedCallsPercent > 0.3d;
             return pedActuationResult;
         }
 

--- a/SPM/Controllers/LeftTurnGapReportController.cs
+++ b/SPM/Controllers/LeftTurnGapReportController.cs
@@ -291,7 +291,8 @@ namespace SPM.Controllers
             {
                 var PedResult = GetPedActuationResult(parameters, approachId);
 
-                approachResult.CyclesWithPedCallNum = PedResult.CyclesWithPedCalls;
+                approachResult.CyclesWithPedCallNum = PedResult.CyclesWithPedCallNum;
+                approachResult.CyclesWithPedCallPercent = PedResult.CyclesWithPedCallPercent;
                 approachResult.PedActuationsConsiderForStudy = PedResult.ConsiderForStudy;
                 approachResult.PercentCyclesWithPedsList = PedResult.PercentCyclesWithPedsList;
                 approachResult.Direction = PedResult.Direction;
@@ -335,7 +336,7 @@ namespace SPM.Controllers
             string url = "PedActuation";
             var result = GetResult(parameters, approachId, url);
             PedActuationResultViewModel pedActuationResult = JsonConvert.DeserializeObject<PedActuationResultViewModel>(result.Content);
-            pedActuationResult.ConsiderForStudy = pedActuationResult.CyclesWithPedCalls > 0.3d;
+            pedActuationResult.ConsiderForStudy = pedActuationResult.CyclesWithPedCallPercent > 0.3d;
             return pedActuationResult;
         }
 

--- a/SPM/Models/PedActuationResultViewModel.cs
+++ b/SPM/Models/PedActuationResultViewModel.cs
@@ -7,8 +7,8 @@ namespace SPM.Models
 {
     public class PedActuationResultViewModel
     {
-        public int CyclesWithPedCallNum { get; set; }
-        public double CyclesWithPedCallPercent { get; set; }
+        public int CyclesWithPedCallsNum { get; set; }
+        public double CyclesWithPedCallsPercent { get; set; }
         public bool ConsiderForStudy { get; set; }
         public Dictionary<DateTime, double> PercentCyclesWithPedsList { get; set; }
         public string Direction { get; set; }

--- a/SPM/Models/PedActuationResultViewModel.cs
+++ b/SPM/Models/PedActuationResultViewModel.cs
@@ -7,8 +7,8 @@ namespace SPM.Models
 {
     public class PedActuationResultViewModel
     {
-        public double PedActuationPercent { get; set; }
-        public int CyclesWithPedCalls { get; set; }
+        public int CyclesWithPedCallNum { get; set; }
+        public double CyclesWithPedCallPercent { get; set; }
         public bool ConsiderForStudy { get; set; }
         public Dictionary<DateTime, double> PercentCyclesWithPedsList { get; set; }
         public string Direction { get; set; }

--- a/SPM/Scripts/LeftTurnReport.js
+++ b/SPM/Scripts/LeftTurnReport.js
@@ -121,11 +121,13 @@ function RunReports() {
     if (timeOptions == "customTimeRadiobutton") {
         StartHour = $("#StartTimeHour :selected").val();
         var StartAMPM = $("#StartAMPM :selected").val();
+        StartHour = parseInt(StartHour);
         if (StartAMPM == "PM") {
             StartHour += 12;
         }
         EndHour = $("#EndTimeHour :selected").val();
         var EndAMPM = $("#EndAMPM :selected").val();
+        EndHour = parseInt(EndHour)
         if (EndAMPM == "PM") {
             EndHour += 12;
         }

--- a/SPM/Views/LeftTurnGapReport/DateSelection.cshtml
+++ b/SPM/Views/LeftTurnGapReport/DateSelection.cshtml
@@ -81,7 +81,7 @@
                     <div class="input-group-custom">
                         @Html.DropDownListFor(model => model.EndTimeHour, HourlistItems, new { @class = "form-control timeWidth" })
                         @Html.DropDownListFor(model => model.EndTimeMinute, MinutelistItems, new { @class = "form-control timeWidth" })
-                        @Html.DropDownListFor(model => model.EndAMPM, AMPMlistItems, new { id = "StartAMPM", @class = "form-control timeWidth", aria_labelledby = "StartAMPM" })
+                        @Html.DropDownListFor(model => model.EndAMPM, AMPMlistItems, new { id = "EndAMPM", @class = "form-control timeWidth", aria_labelledby = "StartAMPM" })
                     </div>
                 </div>
                 </div>

--- a/SPM/Views/LeftTurnGapReport/DateSelection.cshtml
+++ b/SPM/Views/LeftTurnGapReport/DateSelection.cshtml
@@ -81,7 +81,7 @@
                     <div class="input-group-custom">
                         @Html.DropDownListFor(model => model.EndTimeHour, HourlistItems, new { @class = "form-control timeWidth" })
                         @Html.DropDownListFor(model => model.EndTimeMinute, MinutelistItems, new { @class = "form-control timeWidth" })
-                        @Html.DropDownListFor(model => model.EndAMPM, AMPMlistItems, new { id = "EndAMPM", @class = "form-control timeWidth", aria_labelledby = "StartAMPM" })
+                        @Html.DropDownListFor(model => model.EndAMPM, AMPMlistItems, new { id = "EndAMPM", @class = "form-control timeWidth", aria_labelledby = "EndAMPM" })
                     </div>
                 </div>
                 </div>

--- a/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
@@ -42,7 +42,7 @@
 <table class="table table-borderless border-bottom border-primary">
     <tr class="col-8">
         <th class="text-left">
-            <img src="~/Images/NewUDOTLogo.png" width="200" />
+            <img src="@Server.MapPath("~/Images/NewUDOTLogo.png")" width="200" />
         </th>
         <th class="pr-4 mr-4 pl-0">
             <h3>Left Turn Phase</h3>

--- a/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
@@ -42,7 +42,7 @@
 <table class="table table-borderless border-bottom border-primary">
     <tr class="col-8">
         <th class="text-left">
-            <img src="C:\projects\avenue\ATSPM\SPM\Images\NewUDOTLogo.png" width="200" />
+            <img src="~/Images/NewUDOTLogo.png" width="200" />
         </th>
         <th class="pr-4 mr-4 pl-0">
             <h3>Left Turn Phase</h3>

--- a/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/FinalGapAnalysisReport.cshtml
@@ -195,13 +195,13 @@
                         Capacity:
                     </th>
                     <td>
-                        @(result.GapDurationConsiderForStudy.HasValue ? result.Capacity.ToString("N") : "–")
+                        @(result.GapDurationConsiderForStudy.HasValue ? Math.Round(result.Capacity).ToString() : "–")
                     </td>
                     <th>
                         Demand:
                     </th>
                     <td>
-                        @(result.GapDurationConsiderForStudy.HasValue ? result.Demand.ToString("N") : "–")
+                        @(result.GapDurationConsiderForStudy.HasValue ? Math.Round(result.Demand).ToString() : "–")
                     </td>
                     <th>
                         V/C Ratio:
@@ -259,7 +259,7 @@
                         Cycles With Split Failure:
                     </th>
                     <td>
-                        @(result.SplitFailsConsiderForStudy.HasValue ? result.CyclesWithSplitFailNum + "|" + result.CyclesWithSplitFailPercent : "–")
+                        @(result.SplitFailsConsiderForStudy.HasValue ? result.CyclesWithSplitFailNum + " (" + result.CyclesWithSplitFailPercent.ToString("#0.##%") + ")" : "–")
                     </td>
                     <th class="text-left">
                         Left Turn Movement Volume:
@@ -298,7 +298,7 @@
                         Cycles With Pedestrain Calls:
                     </th>
                     <td colspan="2">
-                        @(result.PedActuationsConsiderForStudy.HasValue ? result.CyclesWithPedCallNum.ToString() : "–")
+                        @(result.PedActuationsConsiderForStudy.HasValue ? result.CyclesWithPedCallNum + " (" + result.CyclesWithPedCallPercent.ToString("#0.##%") + ")" : "–")
                     </td>
                     <th class="text-left">
                         Cross Product Value:


### PR DESCRIPTION
- Parsed hours into int before passing to controller. (We were passing 412 to the controller, not 4 + 12)
- Fixed EndAMPM id (was StartAPMPM)
- Passed a number and a percent of cycles with pedcalls to the frontend for the left turn gap report.
- Updated how some numbers were rounded in the report 
- Changed UDOT logo from absolute to relative path
- Split the getAverageForBin into two separate functions, getAverageForBinsByTimeSpan, and get AverageForBinsByApproachId. The first one has been changed to get the sum of the bins by day and then average it out over days. The second takes the approach ID and uses that to find the aggregations for that approach only. This one you may want to discuss with Nuzhat. 
- Expanded the time the precheck looks at
- For flowrate, if either AM or PM is okay then it passes the volumePerHourThreshold. 
- Removed the = for the 15 minute bins, as we were getting extra data
- Add split fail data to chart
