### PR TITLE
Update left turn approaches

### DIFF
--- a/MOE.Common/Business/ApproachVolume/ApproachVolumeChart.cs
+++ b/MOE.Common/Business/ApproachVolume/ApproachVolumeChart.cs
@@ -77,11 +77,9 @@ namespace MOE.Common.Business.ApproachVolume
                     var primaryBin = approachVolume.PrimaryDirectionVolume.Items[i];
                     var opposingBin = approachVolume.OpposingDirectionVolume.Items[i];
                     var combinedBin = approachVolume.CombinedDirectionsVolumes.Items[i];
-                    double direction1DFactor = Convert.ToDouble(primaryBin.YAxis) /
-                                               (Convert.ToDouble(opposingBin.YAxis) +
-                                                Convert.ToDouble(combinedBin.YAxis));
+                    double direction1DFactor = Convert.ToDouble(primaryBin.YAxis) / Convert.ToDouble(combinedBin.YAxis);
                     d1DfactorSeries.Points.AddXY(primaryBin.StartTime.ToOADate(), direction1DFactor);
-                    d2DfactorSeries.Points.AddXY(primaryBin.StartTime.ToOADate(), Convert.ToDouble(opposingBin.YAxis) / (Convert.ToDouble(primaryBin.YAxis) + Convert.ToDouble(combinedBin.YAxis)));
+                    d2DfactorSeries.Points.AddXY(primaryBin.StartTime.ToOADate(), Convert.ToDouble(opposingBin.YAxis) / Convert.ToDouble(combinedBin.YAxis));
                 }
                 Chart.Series.Add(d1DfactorSeries);
                 Chart.Series.Add(d2DfactorSeries);

--- a/MOE.Common/Business/PEDDelay/PEDDelayChart.cs
+++ b/MOE.Common/Business/PEDDelay/PEDDelayChart.cs
@@ -239,7 +239,7 @@ namespace MOE.Common.Business.PEDDelay
                 if (Options.ShowPedRecall)
                 {
                     var vehicleCycles = RedToRedCycles.Where(r => r.StartTime >= plan.StartDate && r.EndTime < plan.EndDate).ToList();
-                    if ((double)plan.PedBeginWalkCount / (double)vehicleCycles.Count * 100 >= Options.PedRecallThreshold)
+                    if (vehicleCycles.Count > 0 && ((double)plan.PedBeginWalkCount / (double)vehicleCycles.Count * 100 >= Options.PedRecallThreshold))
                     {
                         var pedRecallLabel = new CustomLabel();
                         pedRecallLabel.FromPosition = plan.StartDate.ToOADate();

--- a/MOE.Common/Models/Custom/Signal.cs
+++ b/MOE.Common/Models/Custom/Signal.cs
@@ -63,13 +63,11 @@ namespace MOE.Common.Models
 
         public string GetAreasString()
         {
-            var areasString = string.Empty;
+            var areasString = ",";
             foreach (var area in GetAreas())
                 areasString += area.Id + ",";
 
-            if (!string.IsNullOrEmpty(areasString))
-                areasString = areasString.TrimEnd(',');
-            else
+            if (string.IsNullOrEmpty(areasString))
                 areasString = "null";
 
             return areasString;

--- a/MOE.Common/Models/Custom/Signal.cs
+++ b/MOE.Common/Models/Custom/Signal.cs
@@ -67,9 +67,6 @@ namespace MOE.Common.Models
             foreach (var area in GetAreas())
                 areasString += area.Id + ",";
 
-            if (string.IsNullOrEmpty(areasString))
-                areasString = "null";
-
             return areasString;
         }
 

--- a/MOE.Common/Models/Repositories/SignalsRepository.cs
+++ b/MOE.Common/Models/Repositories/SignalsRepository.cs
@@ -41,15 +41,22 @@ namespace MOE.Common.Models.Repositories
                 .Where(signal => signal.VersionActionId != 3)
                 .ToList();
 
+            Signal versionSignal;
             if (signals.Count > 1)
             {
                 var orderedSignals = signals.OrderByDescending(signal => signal.Start);
-                return orderedSignals.First();
+                versionSignal = orderedSignals.First();
             }
             else
             {
-                return signals.FirstOrDefault();
+                versionSignal = signals.FirstOrDefault();
             }
+
+            if (versionSignal != null)
+            {
+                AddSignalAndDetectorLists(versionSignal);
+            }
+            return versionSignal;
         }
 
         public Signal GetVersionOfSignalByDateWithDetectionTypes(string signalId, DateTime startDate)

--- a/SPM/Controllers/LeftTurnGapReportController.cs
+++ b/SPM/Controllers/LeftTurnGapReportController.cs
@@ -71,6 +71,11 @@ namespace SPM.Controllers
                 GapOutThreshold = cyclesWithGapOuts/100
             };
             var checkResults = new List<SignalDataCheckReportViewModel>();
+
+            ViewBag.VolumePerHourThreshold = leftTurnVolume;
+            ViewBag.PedestrianThreshold = cyclesWithPedCalls;
+            ViewBag.GapOutThreshold = cyclesWithGapOuts;
+
             foreach (int approachId in approachIds)
             {
                 dataCheckPayload.ApproachId = approachId;

--- a/SPM/Controllers/LeftTurnGapReportController.cs
+++ b/SPM/Controllers/LeftTurnGapReportController.cs
@@ -28,20 +28,20 @@ namespace SPM.Controllers
         }
 
         // GET: LeftTurnCheckBoxes
-        public ActionResult GetLeftTurnCheckBoxes(string signalID)
+        public ActionResult GetLeftTurnCheckBoxes(string signalID, DateTime date)
         {
             var signalRepository = SignalsRepositoryFactory.Create();
-            var signal = signalRepository.GetLatestVersionOfSignalBySignalID(signalID);
+            var signal = signalRepository.GetVersionOfSignalByDate(signalID, date);
             List<CheckModel> checkModels = new List<CheckModel>{
                 new CheckModel{Id=0, Name = "All Left Turns", Checked = true} };
             foreach (var approach in signal.Approaches)
             {
-                if(approach.Detectors.Any(d => (d.MovementTypeID == 3) && d.DetectionTypeIDs.Contains(4)))
+                if (approach.Detectors.Any(d => (d.MovementTypeID == 3) && d.DetectionTypeIDs.Contains(4)))
                 {
-                    checkModels.Add(new CheckModel { Id = approach.ApproachID, Checked = true, Name = approach.Description});
+                    checkModels.Add(new CheckModel { Id = approach.ApproachID, Checked = true, Name = approach.Description });
                 }
             }
-            return PartialView("LeftTurnCheckBoxes",checkModels);
+            return PartialView("LeftTurnCheckBoxes", checkModels);
         }
 
         static async Task<IRestResponse> SendURI(Uri u, string c)

--- a/SPM/Controllers/LeftTurnGapReportController.cs
+++ b/SPM/Controllers/LeftTurnGapReportController.cs
@@ -71,11 +71,6 @@ namespace SPM.Controllers
                 GapOutThreshold = cyclesWithGapOuts/100
             };
             var checkResults = new List<SignalDataCheckReportViewModel>();
-
-            ViewBag.VolumePerHourThreshold = leftTurnVolume;
-            ViewBag.PedestrianThreshold = cyclesWithPedCalls;
-            ViewBag.GapOutThreshold = cyclesWithGapOuts;
-
             foreach (int approachId in approachIds)
             {
                 dataCheckPayload.ApproachId = approachId;

--- a/SPM/Scripts/LeftTurnReport.js
+++ b/SPM/Scripts/LeftTurnReport.js
@@ -11,6 +11,10 @@
     $(".datepicker").datepicker();
 });
 
+$( "#StartDate" ).change(function () {
+    GetSignalLocation()
+})
+
 $('#RunChecks').click(function () { RunChecks(); });
 
 function RunChecks() {
@@ -265,7 +269,9 @@ function SetControlValues(signalID, selectedMetricID) {
 function GetSignalLocation() {
     var tosend = {};
     var signalID = $("#SignalID").val();
+    var startDate = $("#StartDate").val();
     tosend.signalID = signalID;
+    tosend.date = startDate;
     $.get(urlpathGetLeftTurnCheckBoxes, tosend, function (data) {
         $('#LeftTurnCheckBoxesDiv').html(data);
     });

--- a/SPM/Scripts/Map.js
+++ b/SPM/Scripts/Map.js
@@ -232,7 +232,7 @@ function EndRequest(sender, args) {
 function PinFilterCheck(regionFilter, reportTypeFilter, jurisdictionFilter, areaFilter, pinRegion, pinJurisdiction, areas, pinMetricTypes) {
     if (regionFilter != -1 && regionFilter != pinRegion) return false;
     if (jurisdictionFilter != -1 && jurisdictionFilter != pinJurisdiction) return false;
-    if (areaFilter != -1 && areas.indexOf(areaFilter) == -1) return false;
+    if (areaFilter != -1 && areas.indexOf("," + areaFilter + ",") == -1) return false;
     if (reportTypeFilter != -1 && pinMetricTypes.indexOf(reportTypeFilter) == -1) return false;
     return true;
 }

--- a/SPM/Views/Home/About.cshtml
+++ b/SPM/Views/Home/About.cshtml
@@ -52,10 +52,23 @@
         </div>
         <div class="col-md-4">
             <h2>What's Next</h2>
-            <p>Version 5.0 (Anticipated Release: End of Summer 2022)</p>
+            <p>Version 5.0 (Anticipated Release: 2023)</p>
             <ul>
                 <li>
-                    <p>Migrate from .NET Framework to .NET Core</p>
+                    <b>Backend</b>
+                    <p>-Migrate to .NET 6.0</p>
+                    <p>-Migrate to Entity Framework Core 6.0</p>
+                    <p>-Improved API</p>
+                </li>
+                <li>
+                    <b>New Measures</b>
+                    <p>-Green-Time Distribution</p> 
+                    <p>-Time-Space Diagram</p>
+                </li>
+                <li>
+                    <b>Additional Features</b>
+                    <p>-Options to download data in raw or 15-minute aggregated forms</p>
+                    <p>-Improved data compression</p>
                 </li>
             </ul>
         </div>

--- a/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
@@ -117,7 +117,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Left Turn Volume</td>
-        <td> > @ViewBag.VolumePerHourThreshold vph</td>
+        <td> > @Convert.ToInt32(Model.FirstOrDefault().VolumeThreshold) vph</td>
         @foreach (var check in Model)
         {
     <td>
@@ -134,7 +134,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Gap Out %</td>
-        <td> < @(ViewBag.GapOutThreshold)%</td>
+        <td> < @Convert.ToInt32(Model.FirstOrDefault().GapOutThreshold * 100) %</td>
         @foreach (var check in Model)
         {
     <td>
@@ -151,7 +151,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>% Cycles with Peds</td>
-        <td> < @(ViewBag.PedestrianThreshold)%</td>
+        <td> < @Convert.ToInt32(Model.FirstOrDefault().PedThreshold * 100) %</td>
         @foreach (var check in Model)
         {
     <td>

--- a/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
@@ -117,7 +117,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Left Turn Volume</td>
-        <td> @Convert.ToInt32(Model.First().VolumeThreshold) vph</td>
+        <td> @ViewBag.VolumePerHourThreshold vph</td>
         @foreach (var check in Model)
         {
     <td>
@@ -134,7 +134,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Gap Out %</td>
-        <td>< @Convert.ToInt32(Model.First().GapOutThreshold*100)%</td>
+        <td>< @(ViewBag.GapOutThreshold)%</td>
         @foreach (var check in Model)
         {
     <td>
@@ -151,7 +151,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>% Cycles with Peds</td>
-        <td> < @Convert.ToInt32(Model.First().PedThreshold*100)%</td>
+        <td> < @(ViewBag.PedestrianThreshold)%</td>
         @foreach (var check in Model)
         {
     <td>

--- a/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
+++ b/SPM/Views/LeftTurnGapReport/SignalDataCheckReport.cshtml
@@ -117,7 +117,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Left Turn Volume</td>
-        <td> @ViewBag.VolumePerHourThreshold vph</td>
+        <td> > @ViewBag.VolumePerHourThreshold vph</td>
         @foreach (var check in Model)
         {
     <td>
@@ -134,7 +134,7 @@ Signal data check complete please note the following results:
     </tr>
     <tr>
         <td>Gap Out %</td>
-        <td>< @(ViewBag.GapOutThreshold)%</td>
+        <td> < @(ViewBag.GapOutThreshold)%</td>
         @foreach (var check in Model)
         {
     <td>

--- a/SPM/Views/Signals/SignalDetailResult.cshtml
+++ b/SPM/Views/Signals/SignalDetailResult.cshtml
@@ -83,10 +83,10 @@
                         @Html.DisplayFor(model => model.Longitude)
                     </td>
                     <td>
-                        @Html.CheckBoxFor(model => model.Enabled, new { aria_labelledby = "EnabledHeader" })
+                        @Html.CheckBoxFor(model => model.Enabled, new { aria_labelledby = "EnabledHeader", onclick = "return false", style="pointer-events:none" })
                     </td>
                     <td>
-                        @Html.CheckBoxFor(model => model.Pedsare1to1, new { aria_labelledby = "Pedsare1to1Header" })
+                        @Html.CheckBoxFor(model => model.Pedsare1to1, new { aria_labelledby = "Pedsare1to1Header", onclick = "return false", style = "pointer-events:none" })
                     </td>
                 </tr>
             </table>
@@ -109,7 +109,7 @@
                         @Html.DisplayNameFor(model => model.Approaches.First().PedestrianPhaseNumber)
                     </th>
                     <th>
-                        @Html.LabelFor(model => model.Approaches.First().IsProtectedPhaseOverlap, new { id = "IsProtectedPhaseOverlapHeader", })
+                        @Html.LabelFor(model => model.Approaches.First().IsProtectedPhaseOverlap, new { id = "IsProtectedPhaseOverlapHeader" })
                     </th>
                     <th>
                         @Html.LabelFor(model => model.Approaches.First().IsPermissivePhaseOverlap, new { id = "IsPermissivePhaseOverlapHeader" })
@@ -144,13 +144,13 @@
                             @Html.DisplayFor(modelItem => item.PedestrianPhaseNumber)
                         </td>
                         <td>
-                            @Html.CheckBoxFor(modelItem => item.IsProtectedPhaseOverlap, new { aria_labelledby = "IsProtectedPhaseOverlapHeader" })
+                            @Html.CheckBoxFor(modelItem => item.IsProtectedPhaseOverlap, new { aria_labelledby = "IsProtectedPhaseOverlapHeader", onclick = "return false", style = "pointer-events:none" })
                         </td>
                         <td>
-                            @Html.CheckBoxFor(modelItem => item.IsPermissivePhaseOverlap, new { aria_labelledby = "IsPermissivePhaseOverlapHeader" })
+                            @Html.CheckBoxFor(modelItem => item.IsPermissivePhaseOverlap, new { aria_labelledby = "IsPermissivePhaseOverlapHeader", onclick = "return false", style = "pointer-events:none" })
                         </td>
                         <td>
-                            @Html.CheckBoxFor(modelItem => item.IsPedestrianPhaseOverlap, new { aria_labelledby = "IsPedestrianPhaseOverlapHeader" })
+                            @Html.CheckBoxFor(modelItem => item.IsPedestrianPhaseOverlap, new { aria_labelledby = "IsPedestrianPhaseOverlapHeader", onclick="return false", style = "pointer-events:none" })
                         </td>
                         <td>
                             @Html.DisplayFor(modelItem => item.PedestrianDetectors)


### PR DESCRIPTION
-Fix ped delay so that ped recall is not displayed if no red-to-red cycles are found
-Fix signal data check report to not break if there is an error in the backend and no view models are created.
-Fix left turn gap to use correct signal and approach versions if checking older data.
-Remove ability to check and uncheck checkboxes in the signalDetail display.
-Fix area bug*

*The FilterCheck uses indexOf to match areas to pins. The issue was that "1" also exists in "11", "12", "21". Since the list of areas is passed as a single string, to fix it, I've changed it to require commas on either side. So it now looks for ",1," instead. It's kinda ugly, but I didn't know how much performance we'd lose by parsing it into something more legible, and I didn't want to spend too much time on this because I think we're planning on replacing this in 5.0 or a version soon after. 

The signal repo change I mentioned is the Signal  GetVersionOfSignalByDate method. 
I've updated it to include the AddSignalAndDetectorLists needed to find the left turns.
I don't think adding it should create any issues, and I've tested all the metrics to make sure they still work after changing it. We can extract it into it's own method though if you prefer.